### PR TITLE
Fix incorrect contry-wise gender detection for non iso-8859-15 names …

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,7 @@ Changelog
 * Remove ``unknown_value`` init option, since it can be implemented very easily with a wrapper if needed.
 * Return ``unknown`` when name is not found and ``andy`` when it is valid equally for both male and female.
 * Test README examples as doctests.
+* Fix incorrect country-wise gender detection for non-iso886-15 names coming from line length change after data file conversion to UTF-8. See #gh2. Thanks @miquelcamprodon.
 
 
 0.2.0 (2015-12-06)

--- a/test/test_detector.py
+++ b/test/test_detector.py
@@ -25,6 +25,8 @@ class TestDetector(unittest.TestCase):
         self.assertEqual(self.case.get_gender(u"Jamie"), u"mostly_female")
         self.assertEqual(self.case.get_gender(u"Jamie", u"great_britain"),
                          u"mostly_male")
+        self.assertEqual(self.case.get_gender(u"Alžbeta", "slovakia"), u"female")
+        self.assertEqual(self.case.get_gender(u"Buğra", "turkey"), u"male")
 
     def test_case(self):
         self.assertEqual(self.incase.get_gender(u"sally"), u"female")

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34
+envlist = py2, py3
 
 [pytest]
 addopts = --doctest-glob='*.rst'


### PR DESCRIPTION
…due to incorrect line length. Resolves #2.
