### PR TITLE
Correctly raise the exception for sex not allowed

### DIFF
--- a/gender_guesser/detector.py
+++ b/gender_guesser/detector.py
@@ -6,6 +6,10 @@ class NoCountryError(Exception):
     """Raised when non-supported country is queried"""
     pass
 
+class GenderNotAllowed(Exception):
+    """Raised when non-supported gender"""
+    pass
+
 
 class Detector:
     """Get gender by first name"""
@@ -54,7 +58,7 @@ class Detector:
             elif parts[0] == "?":
                 self._set(name, u"andy", country_values)
             else:
-                raise "Not sure what to do with a sex of %s" % parts[0]
+                raise GenderNotAllowed("Not sure what to do with a sex of %s" % parts[0])
 
     def _set(self, name, gender, country_values):
         """Sets gender and relevant country values for names dictionary of detector"""


### PR DESCRIPTION
You need to raise a class inherit from Exception, not only a single string.


```python
~/src/naveler/utils/gender_helper.py in __init__(self)
     44         dir_path = os.path.abspath(os.path.dirname(__file__))
     45         file_path = os.path.join(dir_path, 'nam_dict.txt')
---> 46         self.gd = gender_detector.Detector(case_sensitive=False, dict_path=file_path)
     47 
     48     @staticmethod

~/src/naveler/venv3/lib/python3.6/site-packages/gender_guesser/detector.py in __init__(self, case_sensitive, dict_path)
     29         if dict_path is None:
     30             dict_path = os.path.join(os.path.dirname(__file__), "data/nam_dict.txt")
---> 31         self._parse(dict_path)
     32 
     33     def _parse(self, filename):

~/src/naveler/venv3/lib/python3.6/site-packages/gender_guesser/detector.py in _parse(self, filename)
     36         with codecs.open(filename, encoding="utf-8") as f:
     37             for line in f:
---> 38                 self._eat_name_line(line.strip())
     39 
     40     def _eat_name_line(self, line):

~/src/naveler/venv3/lib/python3.6/site-packages/gender_guesser/detector.py in _eat_name_line(self, line)
     58                 self._set(name, u"andy", country_values)
     59             else:
---> 60                 raise "Not sure what to do with a sex of %s" % parts[0]
     61 
     62     def _set(self, name, gender, country_values):

TypeError: exceptions must derive from BaseException
```